### PR TITLE
Fix product stock update

### DIFF
--- a/VeraPelle/src/main/java/psw/verapelle/DTO/ProductDTO.java
+++ b/VeraPelle/src/main/java/psw/verapelle/DTO/ProductDTO.java
@@ -13,7 +13,7 @@ public class ProductDTO {
     private BigDecimal price;
     /** @deprecated gestito tramite varianti colore */
     @Deprecated
-    private int stockQuantity;
+    private Integer stockQuantity;
     private List<Long> categoryIds;
 
     /** Liste delle varianti colore con stock dedicato */

--- a/VeraPelle/src/main/java/psw/verapelle/DTO/VariantDTO.java
+++ b/VeraPelle/src/main/java/psw/verapelle/DTO/VariantDTO.java
@@ -8,5 +8,5 @@ public class VariantDTO {
     private Long colorId;
     private String colorName;
     private String hexCode;
-    private int stockQuantity;
+    private Integer stockQuantity;
 }

--- a/VeraPelle/src/main/java/psw/verapelle/service/ProductService.java
+++ b/VeraPelle/src/main/java/psw/verapelle/service/ProductService.java
@@ -99,10 +99,11 @@ public class ProductService {
                     if (productDTO.getPrice() != null) {
                         p.setPrice(productDTO.getPrice());
                     }
-                    // StockQuantity è primitivo, aggiorniamo se >= 0
-                    if (productDTO.getStockQuantity() >= 0) {
+                    // StockQuantity è opzionale: aggiorniamo solo se presente
+                    if (productDTO.getStockQuantity() != null &&
+                            productDTO.getStockQuantity() >= 0) {
                         p.setStockQuantity(productDTO.getStockQuantity());
-                    }  // ← chiusura mancante qui
+                    }
 
                     if (productDTO.getCategoryIds() != null) {
                         p.setCategories(


### PR DESCRIPTION
## Summary
- keep stock quantity optional in `ProductDTO` and `VariantDTO`
- avoid zeroing stock when it isn't provided during product update

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684452a2a39c8324bedd37ed997e688d